### PR TITLE
Fixed mistake in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Create a helloWorld Lightning web component that uses a base component, `c-butto
 <!--helloWorld.html-->
 
 <template>
-    <c-button label="{greeting}" title="greeting"> </c-button>
+    <c-button label={greeting} title="greeting"> </c-button>
 </template>
 ```
 


### PR DESCRIPTION
There is a mistake in template code example: values got from the component fields do not require to be enclosed in quotes.

Thank you for your interest in the base component recipes! We are not accepting pull requests at this time. For questions about base component recipes, use the following channels:

-   [Trailblazer Community - Lightning Web Components](https://success.salesforce.com/ui/core/chatter/groups/GroupProfilePage?g=0F93A000000LlT2SAK)
-   [Salesforce Developer Forums](https://developer.salesforce.com/forums)
-   [Salesforce Stackexchange](https://salesforce.stackexchange.com/)
