### PR TITLE
Update recordForm.js, removed redundant checks

### DIFF
--- a/force-app/main/default/lwc/recordForm/recordForm.js
+++ b/force-app/main/default/lwc/recordForm/recordForm.js
@@ -250,25 +250,20 @@ export default class cRecordForm extends LightningElement {
                         );
                     }
 
-                    const hasFields =
-                        this._objectInfo && this._objectInfo.fields;
-
                     const fieldUpdateable = compound
                         ? compoundFieldIsUpdateable(
                               compoundFields, // eslint-disable-line indent
                               this._record, // eslint-disable-line indent
                               this._objectInfo // eslint-disable-line indent
                           ) // eslint-disable-line indent
-                        : hasFields &&
-                          this._objectInfo.fields[field].updateable;
+                        : this._objectInfo.fields[field].updateable;
                     const fieldCreateable = compound
                         ? compoundFieldIsCreateable(
                               compoundFields, // eslint-disable-line indent
                               this._record, // eslint-disable-line indent
                               this._objectInfo // eslint-disable-line indent
                           ) // eslint-disable-line indent
-                        : hasFields &&
-                          this._objectInfo.fields[field].createable;
+                        : this._objectInfo.fields[field].createable;
                     const shouldShowAsInputInEditMode =
                         fieldUpdateable || (!this._recordId && fieldCreateable);
                     const updateable =
@@ -278,9 +273,7 @@ export default class cRecordForm extends LightningElement {
                     const editable =
                         !isUnsupportedReferenceField(field) &&
                         this._editable &&
-                        (hasFields && this._objectInfo.fields[field]
-                            ? fieldUpdateable
-                            : false);
+                        fieldUpdateable;
                     thisRow.fields.push({
                         field,
                         editable,


### PR DESCRIPTION
_objectinfo is already validated for the field at start of the code block (line 237) => if (this._objectInfo.fields && this._objectInfo.fields[field]) {
similar check is not needed inside the block