### PR TITLE
fix: @W-8389946 Better tree example in the Base Components 

### DIFF
--- a/examples/lwc/treeRecipes/treeRecipes.css
+++ b/examples/lwc/treeRecipes/treeRecipes.css
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+.example-button {
+    margin: 5px;
+}

--- a/examples/lwc/treeRecipes/treeRecipes.css
+++ b/examples/lwc/treeRecipes/treeRecipes.css
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2019, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-.example-button {
-    margin: 5px;
-}

--- a/examples/lwc/treeRecipes/treeRecipes.html
+++ b/examples/lwc/treeRecipes/treeRecipes.html
@@ -21,11 +21,12 @@
                     <c-button
                         onclick={toggleCTO}
                         label="Toggle CTO"
+                        class="slds-m-left_xx-small"
                     ></c-button>
                     <c-button
                         onclick={toggleCFO}
                         label="Toggle CFO"
-                        class="example-button"
+                        class="slds-m-left_xx-small"
                     ></c-button>
                     <c-button
                         onclick={selectDirector}

--- a/examples/lwc/treeRecipes/treeRecipes.html
+++ b/examples/lwc/treeRecipes/treeRecipes.html
@@ -30,7 +30,7 @@
                     ></c-button>
                     <c-button
                         onclick={selectDirector}
-                        label="Select Finance Manager 1"
+                        label="Select Manager 1 under CFO"
                         class="slds-m-left_xx-small"
                     ></c-button>
                     <c-tree

--- a/examples/lwc/treeRecipes/treeRecipes.html
+++ b/examples/lwc/treeRecipes/treeRecipes.html
@@ -13,12 +13,24 @@
                     arrow icons to expand or collapse a branch.
                 </h2>
 
+                <h4>By flipping the '<code>expanded</code>' boolean in the specific node of the items object,
+                    that branch will open or close (toggle).  Notice a selected branch will not collapse.</h4>
+
                 <!-- Simple -->
                 <div class="slds-p-around_medium lgc-bg">
-                    <c-button onclick={toggleCTO} label="Toggle CTO"></c-button>
+                    <c-button
+                        onclick={toggleCTO}
+                        label="Toggle CTO"
+                    ></c-button>
+                    <c-button
+                        onclick={toggleCFO}
+                        label="Toggle CFO"
+                        class="example-button"
+                    ></c-button>
                     <c-button
                         onclick={selectDirector}
-                        label="Select Director"
+                        label="Select Finance Manager 1"
+                        class="slds-m-left_xx-small"
                     ></c-button>
                     <c-tree
                         items={items}

--- a/examples/lwc/treeRecipes/treeRecipes.js
+++ b/examples/lwc/treeRecipes/treeRecipes.js
@@ -23,7 +23,7 @@ export default class TreeRecipes extends LightningElement {
                         {
                             label: 'Manager 1',
                             name: 'CTO-MGR-1',
-                            expanded: true,
+                            expanded: false,
                             items: [
                                 {
                                     label: 'Assistant Manager 1',
@@ -93,7 +93,7 @@ export default class TreeRecipes extends LightningElement {
                 {
                     label: 'Director',
                     name: 'CFO-DIR',
-                    expanded: false,
+                    expanded: true,
                     items: [
                         {
                             label: 'Manager 1',
@@ -103,6 +103,9 @@ export default class TreeRecipes extends LightningElement {
                                 {
                                     label: 'Assistant Manager 1',
                                     name: 'CFO-ASM-1'
+                                }, {
+                                    label: 'Assistant Manager 2',
+                                    name: 'CFO-ASM-2'
                                 }
                             ]
                         },
@@ -121,7 +124,7 @@ export default class TreeRecipes extends LightningElement {
     }
 
     selectDirector() {
-        this.selectedItem = 'CTO-DIR';
+        this.selectedItem = 'CFO-MGR-1';
     }
 
     toggleCTO() {
@@ -129,6 +132,14 @@ export default class TreeRecipes extends LightningElement {
         updatedItems[0] = {
             ...updatedItems[0],
             expanded: !updatedItems[0].expanded
+        };
+        this.items = updatedItems;
+    }
+    toggleCFO() {
+        const updatedItems = JSON.parse(JSON.stringify(this.items));
+        updatedItems[1] = {
+            ...updatedItems[1],
+            expanded: !updatedItems[1].expanded
         };
         this.items = updatedItems;
     }


### PR DESCRIPTION
## Fixes
This pull request addresses GUS item [@W-7806782](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008RvFaIAK/view).

#### Description
From the ticket: When a node other than CTO is selected (such as Director), the Toggle CTO button does not collapse the tree.

The fact is a selected node should not collapse when it is toggled unless the user actually clicks it.

#### Changes in this pull request
- I improved the example so this is made clear.

#### Tests
- [  ] jest tests
- [  ] component tests

#### External Customer Impact
- [ ] [release notes](http://docs.releasenotes.salesforce.com/en-us/spring19/release-notes/rn_lc_nc.htm) (should external customers know about your change?)
- [ ] [component reference](https://developer.salesforce.com/docs/component-library/overview/components) (are you making a change to a global component?)
- this does not apply

#### Impacted Components/Areas
(I don't think this applies.  Pls advise if I am wrong!)