### PR TITLE
Bugfix: lightning combobox triggers virtual keyboard on touch devices

### DIFF
--- a/force-app/main/default/lwc/baseCombobox/baseCombobox.html
+++ b/force-app/main/default/lwc/baseCombobox/baseCombobox.html
@@ -32,6 +32,7 @@
                 class={computedInputClass}
                 type="text"
                 role="textbox"
+                inputmode="none"
                 required={required}
                 autocomplete={autocomplete}
                 value={computedInputValue}


### PR DESCRIPTION
**Steps to reproduce the issue:**
User opens a web page with a `lightning-combobox` like https://developer.salesforce.com/docs/component-library/bundle/lightning-combobox/example on an Android or iOS device and taps on the combobox to open it. 

**Actual behavior:**
Virtual keyboard on iOS and Android opens up


<img src="https://user-images.githubusercontent.com/591424/108210748-f31d3780-7151-11eb-86b5-4aaae903eb06.jpg" alt="Screenshot of issue" width="350" />


**Expected behavior:**
Virtual keyboard on iOS or Android should not open up as the user is supposed to select a value, not type in the combobox

**Fix:**
[As per MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode), `inputmode="none"` when applied to an input tag will stop the trigger of virtual keyboard from happening


I'm aware that you are not accepting Pull Requests, but I'm hoping you can make an exception for this small change or at least acknowledge & fix this issue from your end soon.