### PR TITLE
[DO NOT MERGE] Failed test

### DIFF
--- a/force-app/main/default/lwc/productCard/__test__/getRecord.json
+++ b/force-app/main/default/lwc/productCard/__test__/getRecord.json
@@ -1,0 +1,7 @@
+{
+  "fields": {
+    "Name": {
+      "value": "DYNAMO X1"
+    }
+  }
+}

--- a/force-app/main/default/lwc/productCard/__test__/productCard.spec.js
+++ b/force-app/main/default/lwc/productCard/__test__/productCard.spec.js
@@ -1,0 +1,37 @@
+import {
+    createElement
+} from 'lwc';
+import {registerLdsTestWireAdapter} from '@salesforce/sfdx-lwc-jest';
+import ProductCard from 'c/productCard'; // updated - grabbing locally instead of   ../productCard
+import {getRecord} from 'lightning/uiRecordApi';
+
+// Import mock data to send through the wire adapter.
+const mockGetRecord = require('./data/getRecord.json');
+
+// Register a test wire adapter. - 2.0 way!
+const getRecordWireAdapter = registerLdsTestWireAdapter(getRecord);
+
+describe('@wire demonstration test', () => {
+// Disconnect the component to reset the adapter. It is also
+// a best practice to clean up after each test.
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('displays product name field', () => {
+        const element = createElement('c-product_filter', {
+            is: ProductCard
+        });
+        document.body.appendChild(element);
+        getRecordWireAdapter.emit(mockGetRecord);
+
+// Resolve a promise to wait for a rerender of the new content.
+        return Promise.resolve().then(() => {
+            const content = element.querySelector('.content');
+            const nameField = mockGetRecord.fields.Name.value;
+            expect(content.textContent).toBe(`Name:${nameField}`)
+        });
+    });
+});

--- a/force-app/main/default/lwc/productCard/__test__/productCard.spec.js
+++ b/force-app/main/default/lwc/productCard/__test__/productCard.spec.js
@@ -2,7 +2,7 @@ import {
     createElement
 } from 'lwc';
 import {registerLdsTestWireAdapter} from '@salesforce/sfdx-lwc-jest';
-import ProductCard from 'c/productCard'; // updated - grabbing locally instead of   ../productCard
+import ProductCard from '../productCard'; // updated - grabbing locally instead of c/productCard
 import {getRecord} from 'lightning/uiRecordApi';
 
 // Import mock data to send through the wire adapter.

--- a/force-app/main/default/lwc/productCard/productCard.html
+++ b/force-app/main/default/lwc/productCard/productCard.html
@@ -1,0 +1,11 @@
+<!-- productCard.html -->
+<template>
+    <div class="content">
+        <template if:true={product}>
+            <div class="name">
+                <div>Name:</div>
+                <div>{name}</div>
+            </div>
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/productCard/productCard.js
+++ b/force-app/main/default/lwc/productCard/productCard.js
@@ -1,0 +1,24 @@
+import { LightningElement, wire } from 'lwc';
+
+// Wire adapter to load records.
+import { getRecord } from 'lightning/uiRecordApi';
+
+
+export default class ProductCard extends LightningElement {
+    // Id of Product__c to display.
+    recordId;
+
+    // Product__c to display //
+    product;
+
+    // Product__c field values to display. //
+    name = '';
+
+    @wire(getRecord, { recordId: '$recordId', fields })
+    wiredRecord({ data }) {
+        if (data) {
+            this.product = data;
+            this.name = data.fields.Name.value;
+        }
+    }
+}

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -11,5 +11,5 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "50.0"
+    "sourceApiVersion": "51.0"
 }


### PR DESCRIPTION
npm run test:unit productCard

Gives:
  ● Test suite failed to run

    TypeError: Invalid adapterId, it must be extensible.

      at node_modules/@lwc/jest-preset/src/setup.js:139:23
          at Array.forEach (<anonymous>)
      at overriddenRegisterDecorators (node_modules/@lwc/jest-preset/src/setup.js:126:23)
      at Object.<anonymous> (force-app/main/default/lwc/productCard/productCard.js:36:29)
      at Object.<anonymous> (force-app/main/default/lwc/productCard/__test__/productCard.spec.js:5:1)

Thank you for your interest in the base component recipes! We are not accepting pull requests at this time. For questions about base component recipes, use the following channels:

-   [Trailblazer Community - Lightning Web Components](https://success.salesforce.com/ui/core/chatter/groups/GroupProfilePage?g=0F93A000000LlT2SAK)
-   [Salesforce Developer Forums](https://developer.salesforce.com/forums)
-   [Salesforce Stackexchange](https://salesforce.stackexchange.com/)
